### PR TITLE
Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,7 @@
-FROM lsiobase/rdesktop-web:focal
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:alpine320
 
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN apk add --no-cache anki
 
- RUN \
-  apt-get update && \
-  apt-get install -y anki wget zstd xdg-utils && \
-  dpkg --remove anki && \
-  wget https://github.com/ankitects/anki/releases/download/2.1.54/anki-2.1.54-linux-qt5.tar.zst && \
-  tar --use-compress-program=unzstd -xvf anki-2.1.54-linux-qt5.tar.zst && \
-  cd anki-2.1.54-linux-qt5 && ./install.sh &&  cd .. && \
-  rm -rf anki-2.1.54-linux-qt5 anki-2.1.54-linux-qt5.tar.zst && \
-  apt-get clean && \
-  mkdir -p /config/.local/share && \
-  ln -s /config/app/Anki  /config/.local/share/Anki  && \
-  ln -s /config/app/Anki2 /config/.local/share/Anki2
-
-VOLUME "/config/app" 
-
-COPY root/ /
+COPY /root /

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Anki Desktop
 
-This is a dockerfile for the desktop version of Anki, which is useful for automating anki using addons like Anki-Connect. The app is accessible via a web interface bound to port 3000. The anki configuration is bound to a volume mounted at /config/app in the container. 
+This is a dockerfile for the desktop version of Anki, which is useful for automating anki using addons like Anki-Connect. The app is accessible via a web interface bound to port 3000. The anki configuration is bound to a volume. 
+
+
+## How to build
+
+For creating the docker image please execute:
+```
+docker build -t anki-desktop .
+```
 
 
 ## Docker Compose Examples
@@ -8,18 +16,19 @@ This is a dockerfile for the desktop version of Anki, which is useful for automa
 ### Ports Exposed Directly
 
 ```
-services: 
-  anki-desktop: 
-    image: "pnorcross/anki-desktop:latest"
+services:
+  anki-desktop:
+    image: "anki-desktop:latest"
     volumes:
-      - /data/apps/anki/config:/config/app
-    ports: 
+      # Mount Anki profiles and config directory to host
+      - ./anki:/config/.local/share/Anki2
+    ports:
       - 3000:3000
       # Anki Connect port
       - 8765:8765
  ```
 
-### Proxied through Traefik
+### Proxied through Traefik (outdated)
 
 ```
 services: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-services: 
-  anki-desktop: 
-    image: "pnorcross/anki-desktop:latest"
-    volumes:
-      - /data/apps/anki/config:/config/app
-    ports: 
-      - 3000:3000
-      # Anki Connect port
-      - 8765:8765

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,5 +1,5 @@
+# https://docs.ankiweb.net/platform/windows/display-issues.html#qt5
 mkdir -p /config/app/Anki2 &&
-mkdir -p /config/app/Anki &&
-echo software > /config/.local/share/Anki2/gldriver6 && 
+echo software > /config/.local/share/Anki2/gldriver6 &&
 echo software > /config/.local/share/Anki2/gldriver &&
 export LC_ALL=en_US.UTF-8 && anki

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -1,9 +1,7 @@
-
 <?xml version="1.0" encoding="utf-8"?>
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
-<item label="Anki"><action name="Execute"><command>/usr/bin/anki</command></action></item>
 <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
-<item label="Reload OB"><action name="Reconfigure"/></item>
+<item label="Anki" icon="/usr/share/pixmaps/anki.png"><action name="Execute"><command>/usr/bin/anki</command></action></item>
 </menu>
 </openbox_menu>


### PR DESCRIPTION
Changes to update this image:

- Migrate deprecated base imge lsiobase/rdesktop-web to ghcr.io/linuxserver/baseimage-kasmvnc
- Use edge-channel alpine anki version with `apk add --no-cache anki`
- Update to [24.04.1-r0](https://pkgs.alpinelinux.org/flag/testing/anki/24.04.1-r0), thats the newest version.

I would be happy about a merge.